### PR TITLE
Update to Python 3

### DIFF
--- a/proximityhash2/__init__.py
+++ b/proximityhash2/__init__.py
@@ -1,0 +1,17 @@
+"""
+ Copyright 2017 Ashwin Nair <https://www.linkedin.com/in/nairashwin7>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from .proximityhash import in_circle_check, get_centroid, convert_to_latlon, create_geohash

--- a/proximityhash2/proximityhash.py
+++ b/proximityhash2/proximityhash.py
@@ -1,4 +1,4 @@
-import Geohash
+import geohash2
 import georaptor
 import math
 import time
@@ -80,7 +80,7 @@ def create_geohash(latitude, longitude, radius, precision, georaptor_flag=False,
 
 
     for point in points:
-        geohashes += [Geohash.encode(point[0], point[1], precision)]
+        geohashes += [geohash2.encode(point[0], point[1], precision)]
 
     if georaptor_flag:
         georaptor_out = georaptor.compress(set(geohashes), int(minlevel), int(maxlevel))
@@ -140,7 +140,8 @@ def main():
     puts('\n')
     puts(colored.red('Output:'))
 
-    print(create_geohash(float(latitude), float(longitude), float(radius), int(precision_level), georaptor_flag, int(minlevel), int(maxlevel)))
+    print((create_geohash(float(latitude), float(longitude), float(radius), 
+        int(precision_level), georaptor_flag, int(minlevel), int(maxlevel))))
 
     et = time.time() - start_time
 

--- a/setup.py
+++ b/setup.py
@@ -2,19 +2,19 @@ from distutils.core import setup
 import setuptools
 
 setup(
-  name = 'proximityhash',
-  py_modules = ['proximityhash'],
-  version = '1.0.1',
-  description = 'Geohashes in proximity',
+  name = 'proximityhash2',
+  py_modules = ['proximityhash2'],
+  version = '1.1',
+  description = '(Fixed for Python 3) Geohashes in proximity',
   long_description = open('README.rst').read(),
-  author = 'Ashwin Nair',
-  author_email = 'ashwinnair.ua@gmail.com',
+  author = 'Ashwin Nair, Reid Maulsby',
+  author_email = 'reid.maulsby@gmail.com',
   license = "MIT",
-  url = 'https://github.com/ashwin711/proximityhash',
-  download_url = 'https://github.com/ashwin711/proximityhash/tarball/1.0.1',
+  url = 'https://github.com/rmaulsby/proximityhash',
+  download_url = 'https://github.com/rmaulsby/proximityhash/tarball/1.1',
   keywords = ['geohash', 'optimizer', 'compression', 'geo', 'latitude', 'longitude', 'coordinates', 'proximity', 'circle'],
   classifiers = [
-    'Development Status :: 5 - Production/Stable',
+    'Development Status :: 3 - Alpha',
     'Environment :: Console',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: Apache Software License',
@@ -26,10 +26,10 @@ setup(
 	'clint',
 	'argparse',
     'georaptor>=2.0.3',
-    'Geohash'
+    'geohash2'
   ],
   entry_points='''
 	[console_scripts]
-	proximityhash=proximityhash:main
+	proximityhash2=proximityhash2:main
   '''
 )

--- a/test/test_proximityhash.py
+++ b/test/test_proximityhash.py
@@ -1,7 +1,7 @@
-import unittest
+import unittest2
 import proximityhash
 
-class in_circle_test_case(unittest.TestCase):
+class in_circle_test_case(unittest2.TestCase):
     """Tests for `in_circle_check`."""
     def test_in_circle_check_true(self):
         expected = True
@@ -13,27 +13,27 @@ class in_circle_test_case(unittest.TestCase):
         output = proximityhash.in_circle_check(12, 77, 23, 87, 100)
         self.assertEqual(output, expected)
 
-class centroid_test_case(unittest.TestCase):
+class centroid_test_case(unittest2.TestCase):
     """Tests for `get_centroid`."""
     def test_get_centroid(self):
         expected = (15, 15)
         output = proximityhash.get_centroid(10,10,10,10)
         self.assertEqual(output, expected)
 
-class latlon_convert_test_case(unittest.TestCase):
+class latlon_convert_test_case(unittest2.TestCase):
     """Tests for `convert_to_latlon`."""
     def test_convert_to_latlon(self):
         expected = (12.008993216059187, 77.0091941298557)
         output = proximityhash.convert_to_latlon(1000.0,1000.0, 12.0, 77.0)
         self.assertEqual(output, expected)
 
-class create_geohash_test_case(unittest.TestCase):
+class create_geohash_test_case(unittest2.TestCase):
     """Tests for `create_geohash`."""
     def test_create_geohash(self):
         expected = 'tdnu20t9,tdnu20t8,tdnu20t3,tdnu20t2,tdnu20mz,tdnu20mx,tdnu20tc,tdnu20tb,tdnu20td,tdnu20tf'
         output = proximityhash.create_geohash(12.0, 77.0, 20.0, 8, georaptor_flag=False, minlevel=1, maxlevel=12)
-        self.assertEqual(output, expected)
+        self.assertItemsEqual(output.split(","), expected.split(","))
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()


### PR DESCRIPTION
Updated proximityhash fixes for Python 3. Updated to use geohash2 and unittest2. Fixed bug in test that was showing an assert failing when the output was actually correct. Prepped this to be submitting to PyPi under proximityhash2.